### PR TITLE
DuckDuckGo instead of Google Search + autoredirect

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -1,8 +1,8 @@
 
 let processingorgDocs = 'https://processing.org/reference/';
-let processingorgSearch = 'https://www.google.com/search?as_sitesearch=processing.org&as_q=';
+let processingorgSearch = 'https://duckduckgo.com/?q=!processing+%5C';
 let p5jsDocs = 'https://p5js.org/reference/';
-let p5jsSearch = 'https://www.google.com/search?as_sitesearch=p5js.org&as_q=';
+let p5jsSearch = 'https://duckduckgo.com/?q=!p5+';
 
 import * as vscode from 'vscode';
 


### PR DESCRIPTION
Replace the original Google Search with DuckDuckGo, a privacy-oriented search engine. Aditionally, it automatically redirects to the Processing/p5js site (instead of showing the search results).